### PR TITLE
Refactor y otras cosas

### DIFF
--- a/src/main/java/com/ttps/laboratorio/controller/SampleBatchController.java
+++ b/src/main/java/com/ttps/laboratorio/controller/SampleBatchController.java
@@ -1,12 +1,7 @@
 package com.ttps.laboratorio.controller;
 
-import com.ttps.laboratorio.dto.request.SampleDTO;
-import com.ttps.laboratorio.dto.request.UrlDTO;
-import com.ttps.laboratorio.dto.response.SampleBatchDTO;
-import com.ttps.laboratorio.entity.Sample;
-import com.ttps.laboratorio.service.SampleBatchService;
 import javax.validation.Valid;
-import org.springframework.http.HttpStatus;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.lang.NonNull;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -16,6 +11,10 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import com.ttps.laboratorio.dto.request.UrlDTO;
+import com.ttps.laboratorio.dto.response.SampleBatchDTO;
+import com.ttps.laboratorio.service.SampleBatchService;
 
 @RestController
 @RequestMapping(path = "sample-batch")
@@ -43,7 +42,7 @@ public class SampleBatchController {
 	@PreAuthorize("hasRole('EMPLOYEE')")
 	@PostMapping(path = "/{id}/url")
 	public ResponseEntity<SampleBatchDTO> uploadResultsUrl(@PathVariable(name = "id") @NonNull Long sampleBatchId,
-																						 @Valid @RequestBody UrlDTO urlDTO) {
+			@Valid @RequestBody UrlDTO urlDTO) {
 		return ResponseEntity.ok(sampleBatchService.uploadResults(sampleBatchId, urlDTO));
 	}
 

--- a/src/main/java/com/ttps/laboratorio/dto/response/SampleBatchDTO.java
+++ b/src/main/java/com/ttps/laboratorio/dto/response/SampleBatchDTO.java
@@ -1,11 +1,11 @@
 package com.ttps.laboratorio.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.ttps.laboratorio.entity.Sample;
-import com.ttps.laboratorio.entity.SampleBatchStatus;
-import com.ttps.laboratorio.entity.Study;
 import java.util.ArrayList;
 import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.ttps.laboratorio.entity.SampleBatchStatus;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -22,10 +22,8 @@ public class SampleBatchDTO {
 
 	private SampleBatchStatus status;
 
-	private List<Study> studies = new ArrayList<>();
-
 	private String finalReportsUrl;
 
-	private List<Sample> samples = new ArrayList<>();
+	private List<SampleDTO> samples = new ArrayList<>();
 
 }

--- a/src/main/java/com/ttps/laboratorio/dto/response/SampleDTO.java
+++ b/src/main/java/com/ttps/laboratorio/dto/response/SampleDTO.java
@@ -1,0 +1,22 @@
+package com.ttps.laboratorio.dto.response;
+
+import java.io.Serializable;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class SampleDTO implements Serializable {
+
+	private static final long serialVersionUID = -5000253122926959427L;
+
+	private Long id;
+	private Long studyId;
+	private Boolean failed;
+	private Double milliliters;
+	private Integer freezer;
+
+}

--- a/src/main/java/com/ttps/laboratorio/entity/Checkpoint.java
+++ b/src/main/java/com/ttps/laboratorio/entity/Checkpoint.java
@@ -1,9 +1,9 @@
 package com.ttps.laboratorio.entity;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.Comparator;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -12,6 +12,9 @@ import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/ttps/laboratorio/entity/FinalReport.java
+++ b/src/main/java/com/ttps/laboratorio/entity/FinalReport.java
@@ -1,8 +1,8 @@
 package com.ttps.laboratorio.entity;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.io.Serializable;
 import java.time.LocalDateTime;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -14,6 +14,9 @@ import javax.persistence.ManyToOne;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -31,6 +34,8 @@ import lombok.ToString;
 @Entity
 @Table(name = "final_reports")
 public class FinalReport implements Serializable {
+
+	private static final long serialVersionUID = 1L;
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/ttps/laboratorio/entity/Sample.java
+++ b/src/main/java/com/ttps/laboratorio/entity/Sample.java
@@ -9,7 +9,6 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
-import javax.persistence.OneToOne;
 import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
 
@@ -47,9 +46,12 @@ public class Sample implements Serializable {
 	@Column(name = "freezer", nullable = false)
 	private Integer freezer;
 
+	@Column(name = "failed", nullable = true)
+	private Boolean failed;
+
 	@JsonIgnore
-	@OneToOne(optional = false)
-	@JoinColumn(name = "study_id")
+	@ManyToOne(optional = false)
+	@JoinColumn(name = "study_id", referencedColumnName = "id")
 	private Study study;
 
 	@ManyToOne(optional = true)

--- a/src/main/java/com/ttps/laboratorio/entity/Study.java
+++ b/src/main/java/com/ttps/laboratorio/entity/Study.java
@@ -1,13 +1,12 @@
 package com.ttps.laboratorio.entity;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -15,11 +14,16 @@ import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -45,6 +49,7 @@ public class Study implements Serializable {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
+	@Builder.Default
 	@Column(name = "created_at")
 	private LocalDateTime createdAt = LocalDateTime.now();
 
@@ -56,6 +61,7 @@ public class Study implements Serializable {
 	@Column(name = "extraction_amount", nullable = false)
 	private BigDecimal extractionAmount;
 
+	@Builder.Default
 	@Column(name = "paid_extraction_amount")
 	private Boolean paidExtractionAmount = false;
 
@@ -65,6 +71,7 @@ public class Study implements Serializable {
 	/**
 	 * Maybe this has to be deleted and calculated.
 	 */
+	@Builder.Default
 	@Column(name = "delay")
 	private Boolean delay = false;
 
@@ -108,7 +115,8 @@ public class Study implements Serializable {
 	/**
 	 * Sample represents the blood extraction of the study
 	 */
-	@OneToOne(mappedBy = "study", optional = true, cascade = CascadeType.ALL, orphanRemoval = true)
+	@ManyToOne(optional = true, cascade = CascadeType.ALL)
+	@JoinColumn(name = "sample_id", referencedColumnName = "id")
 	private Sample sample;
 
 	@Builder.Default
@@ -132,6 +140,22 @@ public class Study implements Serializable {
 	 */
 	public StudyStatus getActualStatus() {
 		return Optional.ofNullable(getRecentCheckpoint()).map(Checkpoint::getStatus).orElse(null);
+	}
+
+	public void setFinalReport(FinalReport finalReport) {
+		this.finalReport = finalReport;
+		finalReport.setStudy(this);
+	}
+
+	public void setSample(Sample sample) {
+		this.sample = sample;
+		if (sample != null)
+			sample.setStudy(this);
+	}
+
+	public boolean addCheckpoint(Checkpoint checkpoint) {
+		checkpoint.setStudy(this);
+		return this.checkpoints.add(checkpoint);
 	}
 
 }

--- a/src/main/java/com/ttps/laboratorio/repository/IStudyRepository.java
+++ b/src/main/java/com/ttps/laboratorio/repository/IStudyRepository.java
@@ -1,19 +1,21 @@
 package com.ttps.laboratorio.repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
 import com.ttps.laboratorio.entity.Appointment;
 import com.ttps.laboratorio.entity.Patient;
 import com.ttps.laboratorio.entity.Sample;
 import com.ttps.laboratorio.entity.Study;
 import com.ttps.laboratorio.entity.StudyStatus;
 import com.ttps.laboratorio.entity.StudyType;
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-import org.springframework.stereotype.Repository;
 
 @Repository
 public interface IStudyRepository extends JpaRepository<Study, Long>, JpaSpecificationExecutor<Study> {

--- a/src/main/java/com/ttps/laboratorio/service/ExtractionistService.java
+++ b/src/main/java/com/ttps/laboratorio/service/ExtractionistService.java
@@ -1,15 +1,17 @@
 package com.ttps.laboratorio.service;
 
-import com.ttps.laboratorio.entity.Checkpoint;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.ttps.laboratorio.entity.Extractionist;
 import com.ttps.laboratorio.entity.Study;
 import com.ttps.laboratorio.entity.StudyStatus;
 import com.ttps.laboratorio.exception.BadRequestException;
 import com.ttps.laboratorio.exception.NotFoundException;
 import com.ttps.laboratorio.repository.IExtractionistRepository;
-import java.util.ArrayList;
-import java.util.List;
-import org.springframework.stereotype.Service;
 
 @Service
 public class ExtractionistService {
@@ -39,23 +41,24 @@ public class ExtractionistService {
 		return new ArrayList<>(extractionistRepository.findAll());
 	}
 
+	@Transactional
 	public void setExtractionistById(Long studyId, Long extractionistId) {
 		Study study = studyService.getStudy(studyId);
 		if (study.getActualStatus() != null && !study.getActualStatus().getId().equals(StudyStatus.ESPERANDO_RETIRO_DE_MUESTRA)) {
 			throw new BadRequestException("El estudio #" + studyId + " no se encuentra en el estado correspondiente para seleccionar al extraccionista.");
 		}
 		study.setExtractionist(getExtractionist(extractionistId));
-		studyService.setCheckpointWithStatus(StudyStatus.ESPERANDO_LOTE_DE_MUESTRA_PARA_INICIAR_PROCESAMIENTO, study);
+		studyService.addCheckpointWithLoggedUser(StudyStatus.ESPERANDO_LOTE_DE_MUESTRA_PARA_INICIAR_PROCESAMIENTO,
+				study);
 		studyService.saveFlushStudy(study);
 		StudyStatus statusWaitingForPayment = studyStatusService.getStudyStatus(StudyStatus.ESPERANDO_LOTE_DE_MUESTRA_PARA_INICIAR_PROCESAMIENTO);
 		List<Study> studiesReadyForProcess = studyService.getStudiesByActualStatus(statusWaitingForPayment);
 		if (studiesReadyForProcess != null && studiesReadyForProcess.size() == SampleBatchService.SAMPLE_BATCH_COUNT) {
 			studiesReadyForProcess.forEach(s -> {
-				Checkpoint checkpoint = new Checkpoint();
-				checkpoint.setStudy(s);
-				checkpoint.setCreatedBy(null);
-				checkpoint.setStatus(studyStatusService.getStudyStatus(StudyStatus.ESPERANDO_RESULTADO_BIOTECNOLOGICO));
-				s.getCheckpoints().add(checkpoint);
+				// we register the user that creates the batch
+				studyService.addCheckpointWithLoggedUser(StudyStatus.ESPERANDO_RESULTADO_BIOTECNOLOGICO, study);
+				// studyService.addNewCheckpoint(study,
+				// StudyStatus.ESPERANDO_RESULTADO_BIOTECNOLOGICO, null);
 				studyService.saveStudy(s);
 			});
 			sampleBatchService.createBatch(studiesReadyForProcess);

--- a/src/main/java/com/ttps/laboratorio/service/FinalReportService.java
+++ b/src/main/java/com/ttps/laboratorio/service/FinalReportService.java
@@ -13,7 +13,6 @@ import com.ttps.laboratorio.entity.StudyStatus;
 import com.ttps.laboratorio.entity.User;
 import com.ttps.laboratorio.exception.BadRequestException;
 import com.ttps.laboratorio.exception.LaboratoryException;
-import com.ttps.laboratorio.repository.IFinalReportRepository;
 import com.ttps.laboratorio.utils.LaboratoryFileUtils;
 
 import lombok.extern.slf4j.Slf4j;
@@ -21,8 +20,6 @@ import lombok.extern.slf4j.Slf4j;
 @Service
 @Slf4j
 public class FinalReportService {
-
-	private final IFinalReportRepository finalReportRepository;
 
 	private final StudyService studyService;
 
@@ -34,8 +31,8 @@ public class FinalReportService {
 
 	private final PdfGeneratorService pdfGeneratorService;
 
-	public FinalReportService(IFinalReportRepository finalReportRepository, StudyService studyService, UserService userService, EmployeeService employeeService, LaboratoryFileUtils laboratoryFileUtils, PdfGeneratorService pdfGeneratorService) {
-		this.finalReportRepository = finalReportRepository;
+	public FinalReportService(StudyService studyService, UserService userService, EmployeeService employeeService,
+			LaboratoryFileUtils laboratoryFileUtils, PdfGeneratorService pdfGeneratorService) {
 		this.studyService = studyService;
 		this.userService = userService;
 		this.employeeService = employeeService;

--- a/src/main/java/com/ttps/laboratorio/service/FinalReportService.java
+++ b/src/main/java/com/ttps/laboratorio/service/FinalReportService.java
@@ -1,5 +1,10 @@
 package com.ttps.laboratorio.service;
 
+import java.io.IOException;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.ttps.laboratorio.dto.request.FinalReportDTO;
 import com.ttps.laboratorio.entity.Employee;
 import com.ttps.laboratorio.entity.FinalReport;
@@ -10,9 +15,8 @@ import com.ttps.laboratorio.exception.BadRequestException;
 import com.ttps.laboratorio.exception.LaboratoryException;
 import com.ttps.laboratorio.repository.IFinalReportRepository;
 import com.ttps.laboratorio.utils.LaboratoryFileUtils;
-import java.io.IOException;
+
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
 
 @Service
 @Slf4j
@@ -39,22 +43,24 @@ public class FinalReportService {
 		this.pdfGeneratorService = pdfGeneratorService;
 	}
 
+	@Transactional(rollbackFor = { LaboratoryException.class, Exception.class })
 	public FinalReport createFinalReport(Long studyId, FinalReportDTO finalReportDTO) {
 		Study study = studyService.getStudy(studyId);
 		if (study.getActualStatus() != null && !study.getActualStatus().getId().equals(StudyStatus.ESPERANDO_INTERPRETACION_DE_RESULTADOS)) {
 			throw new BadRequestException(
 					"El estudio #" + studyId + " no se encuentra en el estado correspondiente para ingresar el reporte final.");
 		}
-		FinalReport finalReport = new FinalReport();
-		finalReport.setPositiveResult(finalReportDTO.getPositiveResult());
 		User queriedUser = userService.getLoggedUser();
 		Employee employee = employeeService.getByUser(queriedUser);
+		FinalReport.builder().medicalInformant(employee).positiveResult(finalReportDTO.getPositiveResult())
+				.report(finalReportDTO.getReport()).build();
+		FinalReport finalReport = new FinalReport();
+		finalReport.setPositiveResult(finalReportDTO.getPositiveResult());
 		finalReport.setMedicalInformant(employee);
 		finalReport.setReport(finalReportDTO.getReport());
 		finalReport.setStudy(study);
-		finalReportRepository.save(finalReport);
 		study.setFinalReport(finalReport);
-		studyService.setCheckpointWithStatus(StudyStatus.ESPERANDO_SER_ENTREGADO_A_MEDICO_DERIVANTE, study);
+		studyService.addCheckpointWithLoggedUser(StudyStatus.ESPERANDO_SER_ENTREGADO_A_MEDICO_DERIVANTE, study);
 		studyService.saveStudy(study);
 		try {
 			String filename = laboratoryFileUtils.getFilenameFinalReport(study.getPatient().getId(), study.getId());

--- a/src/main/java/com/ttps/laboratorio/service/MetricsService.java
+++ b/src/main/java/com/ttps/laboratorio/service/MetricsService.java
@@ -1,16 +1,16 @@
 package com.ttps.laboratorio.service;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
 import com.ttps.laboratorio.constants.Months;
 import com.ttps.laboratorio.dto.response.StudiesByMonthDTO;
 import com.ttps.laboratorio.dto.response.StudiesByMonthOfYearDTO;
 import com.ttps.laboratorio.dto.response.StudiesByStudyTypeDTO;
 import com.ttps.laboratorio.entity.StudyType;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import org.springframework.stereotype.Service;
 
 @Service
 public class MetricsService {

--- a/src/main/java/com/ttps/laboratorio/service/SampleBatchService.java
+++ b/src/main/java/com/ttps/laboratorio/service/SampleBatchService.java
@@ -5,9 +5,11 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.ttps.laboratorio.dto.request.UrlDTO;
 import com.ttps.laboratorio.dto.response.SampleBatchDTO;
+import com.ttps.laboratorio.dto.response.SampleDTO;
 import com.ttps.laboratorio.entity.Sample;
 import com.ttps.laboratorio.entity.SampleBatch;
 import com.ttps.laboratorio.entity.SampleBatchStatus;
@@ -24,7 +26,7 @@ public class SampleBatchService {
 
 	private final StudyService studyService;
 
-	public static final Integer SAMPLE_BATCH_COUNT = 10;
+	public static final Integer SAMPLE_BATCH_COUNT = 2;
 
 	public SampleBatchService(ISampleBatchRepository sampleBatchRepository, StudyService studyService) {
 		this.sampleBatchRepository = sampleBatchRepository;
@@ -44,7 +46,9 @@ public class SampleBatchService {
 		response.setStatus(sampleBatch.getStatus());
 		response.setId(sampleBatch.getId());
 		response.setFinalReportsUrl(sampleBatch.getFinalReportsUrl());
-		response.setStudies(sampleBatch.getSamples().stream().map(s -> s.getStudy()).collect(Collectors.toList()));
+		response.setSamples(sampleBatch.getSamples().stream().map(
+				s -> new SampleDTO(s.getId(), s.getStudy().getId(), s.getFailed(), s.getMilliliters(), s.getFreezer()))
+				.collect(Collectors.toList()));
 		return response;
 	}
 
@@ -52,6 +56,7 @@ public class SampleBatchService {
 		return new ArrayList<>(sampleBatchRepository.findAll());
 	}
 
+	@Transactional
 	public SampleBatchDTO uploadResults(Long sampleBatchId, UrlDTO urlDTO) {
 		SampleBatch sampleBatch = sampleBatchRepository.findById(sampleBatchId)
 				.orElseThrow(() -> new NotFoundException("No existe un lote con el id " + sampleBatchId + "."));
@@ -67,11 +72,14 @@ public class SampleBatchService {
 				.filter(s -> !urlDTO.getFailedSamples().contains(s.getId())).collect(Collectors.toList());
 
 		failedSamples.forEach(sample -> {
-			studyService.setCheckpointWithStatus(StudyStatus.ESPERANDO_SELECCION_DE_TURNO, sample.getStudy());
+			sample.setFailed(true);
+			sample.getStudy().setSample(null);
+			studyService.addCheckpointWithLoggedUser(StudyStatus.ESPERANDO_SELECCION_DE_TURNO, sample.getStudy());
 			studyService.saveStudy(sample.getStudy());
 		});
 		successfulSamples.forEach(sample -> {
-			studyService.setCheckpointWithStatus(StudyStatus.ESPERANDO_INTERPRETACION_DE_RESULTADOS, sample.getStudy());
+			sample.setFailed(false);
+			studyService.addCheckpointWithLoggedUser(StudyStatus.ESPERANDO_INTERPRETACION_DE_RESULTADOS, sample.getStudy());
 			studyService.saveStudy(sample.getStudy());
 		});
 		sampleBatch.setStatus(SampleBatchStatus.PROCESSED);

--- a/src/main/java/com/ttps/laboratorio/service/SampleService.java
+++ b/src/main/java/com/ttps/laboratorio/service/SampleService.java
@@ -8,17 +8,13 @@ import com.ttps.laboratorio.entity.Sample;
 import com.ttps.laboratorio.entity.Study;
 import com.ttps.laboratorio.entity.StudyStatus;
 import com.ttps.laboratorio.exception.BadRequestException;
-import com.ttps.laboratorio.repository.ISampleRepository;
 
 @Service
 public class SampleService {
 
-	private final ISampleRepository sampleRepository;
-
 	private final StudyService studyService;
 
-	public SampleService(ISampleRepository sampleRepository, StudyService studyService) {
-		this.sampleRepository = sampleRepository;
+	public SampleService(StudyService studyService) {
 		this.studyService = studyService;
 	}
 

--- a/src/main/java/com/ttps/laboratorio/service/SampleService.java
+++ b/src/main/java/com/ttps/laboratorio/service/SampleService.java
@@ -1,6 +1,7 @@
 package com.ttps.laboratorio.service;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.ttps.laboratorio.dto.request.SampleDTO;
 import com.ttps.laboratorio.entity.Sample;
@@ -21,6 +22,7 @@ public class SampleService {
 		this.studyService = studyService;
 	}
 
+	@Transactional
 	public Sample createSample(Long studyId, SampleDTO request) {
 		Study study = studyService.getStudy(studyId);
 		if (study.getActualStatus() != null && !study.getActualStatus().getId().equals(StudyStatus.ESPERANDO_TOMA_DE_MUESTRA)) {
@@ -28,26 +30,11 @@ public class SampleService {
 					"El estudio #" + studyId
 							+ " no se encuentra en el estado correspondiente para ingresar datos de muestra.");
 		}
-		Sample sample = new Sample();
-		if (study.getSample() != null) {
-			sample = updateSample(study, request);
-		} else {
-			sample.setMilliliters(request.getMilliliters());
-			sample.setFreezer(request.getFreezer());
-			sample.setStudy(study);
-			study.setSample(sample);
-		}
-		sampleRepository.save(sample);
-		studyService.setCheckpointWithStatus(StudyStatus.ESPERANDO_RETIRO_DE_MUESTRA, study);
+		Sample sample = Sample.builder().freezer(request.getFreezer()).milliliters(request.getMilliliters()).build();
+		study.setSample(sample);
+		studyService.addCheckpointWithLoggedUser(StudyStatus.ESPERANDO_RETIRO_DE_MUESTRA, study);
 		studyService.saveStudy(study);
 		return sample;
-	}
-
-	private Sample updateSample(Study study, SampleDTO request) {
-		study.getSample().setFreezer(request.getFreezer());
-		study.getSample().setMilliliters(request.getMilliliters());
-		study.getSample().setSampleBatch(null);
-		return study.getSample();
 	}
 
 }

--- a/src/main/java/com/ttps/laboratorio/service/StudyService.java
+++ b/src/main/java/com/ttps/laboratorio/service/StudyService.java
@@ -1,5 +1,22 @@
 package com.ttps.laboratorio.service;
 
+import java.io.File;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.modelmapper.ModelMapper;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
 import com.ttps.laboratorio.dto.request.StudyDTO;
 import com.ttps.laboratorio.dto.request.StudySearchFilterDTO;
 import com.ttps.laboratorio.dto.request.UnpaidStudiesDTO;
@@ -18,22 +35,8 @@ import com.ttps.laboratorio.exception.NotFoundException;
 import com.ttps.laboratorio.repository.IStudyRepository;
 import com.ttps.laboratorio.repository.specification.StudySpecifications;
 import com.ttps.laboratorio.utils.LaboratoryFileUtils;
-import java.io.File;
-import java.io.IOException;
-import java.math.BigDecimal;
-import java.nio.file.Files;
-import java.nio.file.StandardCopyOption;
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.stream.Collectors;
+
 import lombok.extern.slf4j.Slf4j;
-import org.modelmapper.ModelMapper;
-import org.springframework.core.io.FileSystemResource;
-import org.springframework.core.io.Resource;
-import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @Slf4j
@@ -60,9 +63,9 @@ public class StudyService {
 	private final LaboratoryFileUtils laboratoryFileUtils;
 
 	public StudyService(IStudyRepository studyRepository, PatientService patientService, UserService userService,
-											StudyStatusService studyStatusService, DoctorService doctorService, StudyTypeService studyTypeService,
-											PresumptiveDiagnosisService presumptiveDiagnosisService, PdfGeneratorService pdfGeneratorService,
-											LaboratoryFileUtils fileNameUtils) {
+			StudyStatusService studyStatusService, DoctorService doctorService, StudyTypeService studyTypeService,
+			PresumptiveDiagnosisService presumptiveDiagnosisService, PdfGeneratorService pdfGeneratorService,
+			LaboratoryFileUtils fileNameUtils) {
 		this.studyRepository = studyRepository;
 		this.patientService = patientService;
 		this.userService = userService;
@@ -104,7 +107,7 @@ public class StudyService {
 		}).collect(Collectors.toList());
 	}
 
-	@Transactional(rollbackFor = {LaboratoryException.class, Exception.class})
+	@Transactional(rollbackFor = { LaboratoryException.class, Exception.class })
 	public Study createStudy(Long patientId, StudyDTO request) {
 		Study study = new Study();
 		Patient patient = patientService.getPatient(patientId);
@@ -115,7 +118,7 @@ public class StudyService {
 		study.setType(studyTypeService.getStudyType(request.getStudyType().getId()));
 		study.setPresumptiveDiagnosis(
 				presumptiveDiagnosisService.getPresumptiveDiagnosis(request.getPresumptiveDiagnosis().getId()));
-		setCheckpointWithStatus(StudyStatus.ESPERANDO_COMPROBANTE_DE_PAGO, study);
+		addCheckpointWithLoggedUser(StudyStatus.ESPERANDO_COMPROBANTE_DE_PAGO, study);
 		study = studyRepository.save(study);
 		try {
 			String filename = laboratoryFileUtils.getFilenameBudget(study.getPatient().getId(), study.getId());
@@ -159,7 +162,7 @@ public class StudyService {
 		return study;
 	}
 
-	@Transactional(rollbackFor = {LaboratoryException.class, Exception.class})
+	@Transactional(rollbackFor = { LaboratoryException.class, Exception.class })
 	public Study confirmPayment(Long studyId, boolean confirm) {
 		Study study = studyRepository.findById(studyId)
 				.orElseThrow(() -> new NotFoundException("No existe un estudio #" + studyId + "."));
@@ -185,7 +188,7 @@ public class StudyService {
 		// else change status to back (ESPERANDO_COMPROBANTE_DE_PAGO)
 		Long studyStatus = confirm ? StudyStatus.ENVIAR_CONSENTIMIENTO_INFORMADO
 				: StudyStatus.ESPERANDO_COMPROBANTE_DE_PAGO;
-		setCheckpointWithStatus(studyStatus, study);
+		addCheckpointWithLoggedUser(studyStatus, study);
 		return studyRepository.save(study);
 	}
 
@@ -260,7 +263,7 @@ public class StudyService {
 
 		// Change state only if actual state is Enviar consentimiento informado
 		if (study.getActualStatus().getId().equals(StudyStatus.ENVIAR_CONSENTIMIENTO_INFORMADO)) {
-			setCheckpointWithStatus(StudyStatus.ESPERANDO_CONSENTIMIENTO_INFORMADO_FIRMADO, study);
+			addCheckpointWithLoggedUser(StudyStatus.ESPERANDO_CONSENTIMIENTO_INFORMADO_FIRMADO, study);
 			study = studyRepository.save(study);
 		}
 		return new FileSystemResource(file);
@@ -283,8 +286,7 @@ public class StudyService {
 		String filename = laboratoryFileUtils.getFilenameSignedConsent(study.getPatient().getId(), study.getId());
 		File file = new File(filename);
 		if (!file.exists()) {
-			throw new LaboratoryException(
-					"No existe el documento de consentimiento firmado del estudio #" + studyId);
+			throw new LaboratoryException("No existe el documento de consentimiento firmado del estudio #" + studyId);
 		}
 		return new FileSystemResource(file);
 	}
@@ -305,19 +307,19 @@ public class StudyService {
 		String filename = laboratoryFileUtils.getFilenameFinalReport(study.getPatient().getId(), study.getId());
 		File file = new File(filename);
 		if (!file.exists()) {
-			throw new LaboratoryException(
-					"No existe el documento de reporte final del estudio #" + studyId);
+			throw new LaboratoryException("No existe el documento de reporte final del estudio #" + studyId);
 		}
 
-		// Change state only if actual state is Esperando ser entregado a medico derivante
+		// Change state only if actual state is Esperando ser entregado a medico
+		// derivante
 		if (study.getActualStatus().getId().equals(StudyStatus.ESPERANDO_SER_ENTREGADO_A_MEDICO_DERIVANTE)) {
-			setCheckpointWithStatus(StudyStatus.RESULTADO_ENTREGADO, study);
+			addCheckpointWithLoggedUser(StudyStatus.RESULTADO_ENTREGADO, study);
 			studyRepository.save(study);
 		}
 		return new FileSystemResource(file);
 	}
 
-	@Transactional(rollbackFor = {LaboratoryException.class, Exception.class})
+	@Transactional(rollbackFor = { LaboratoryException.class, Exception.class })
 	public Study uploadPaymentProofFile(Long studyId, MultipartFile paymentProofPdf) {
 		Study study = studyRepository.findById(studyId)
 				.orElseThrow(() -> new NotFoundException("No existe un estudio #" + studyId + "."));
@@ -335,7 +337,7 @@ public class StudyService {
 			String filename = laboratoryFileUtils.getFilenamePaymentProof(study.getPatient().getId(), study.getId());
 			File file = new File(filename);
 			Files.copy(paymentProofPdf.getInputStream(), file.toPath(), StandardCopyOption.REPLACE_EXISTING);
-			setCheckpointWithStatus(StudyStatus.ESPERANDO_VALIDACION_COMPROBANTE_DE_PAGO, study);
+			addCheckpointWithLoggedUser(StudyStatus.ESPERANDO_VALIDACION_COMPROBANTE_DE_PAGO, study);
 			study = studyRepository.save(study);
 		} catch (IOException e) {
 			throw new LaboratoryException(
@@ -364,7 +366,7 @@ public class StudyService {
 			String filename = laboratoryFileUtils.getFilenameSignedConsent(study.getPatient().getId(), study.getId());
 			File file = new File(filename);
 			Files.copy(signedConsentPdf.getInputStream(), file.toPath(), StandardCopyOption.REPLACE_EXISTING);
-			setCheckpointWithStatus(StudyStatus.ESPERANDO_SELECCION_DE_TURNO, study);
+			addCheckpointWithLoggedUser(StudyStatus.ESPERANDO_SELECCION_DE_TURNO, study);
 			study = studyRepository.save(study);
 		} catch (IOException e) {
 			throw new LaboratoryException(
@@ -385,13 +387,29 @@ public class StudyService {
 		return studyRepository.saveAndFlush(study);
 	}
 
-	public void setCheckpointWithStatus(Long status, Study study) {
-		User queriedUser = userService.getLoggedUser();
-		Checkpoint checkpoint = new Checkpoint();
-		checkpoint.setStudy(study);
-		checkpoint.setCreatedBy(queriedUser);
-		checkpoint.setStatus(studyStatusService.getStudyStatus(status));
-		study.getCheckpoints().add(checkpoint);
+	/**
+	 * Creates a checkpoint with params and adds to study checkpoints collection
+	 * 
+	 * @param study  Owner of the checkpoint
+	 * @param status Id of status of study for checkpoint
+	 * @param user   User that performs the operation or null
+	 */
+	public void addNewCheckpoint(Study study, Long status, User user) {
+		StudyStatus studyStatus = studyStatusService.getStudyStatus(status);
+		Checkpoint checkpoint = Checkpoint.builder().status(studyStatus).createdBy(user).build();
+		study.addCheckpoint(checkpoint);
+	}
+
+	/**
+	 * Creates a checkpoint with params for authenticated user and adds to study
+	 * checkpoints collection
+	 * 
+	 * @param status
+	 * @param study
+	 */
+	public void addCheckpointWithLoggedUser(Long status, Study study) {
+		User user = userService.getLoggedUser();
+		addNewCheckpoint(study, status, user);
 	}
 
 	public List<Study> getStudiesByActualStatus(StudyStatus studyStatus) {
@@ -399,26 +417,24 @@ public class StudyService {
 	}
 
 	@Scheduled(cron = "0 0 0 * * ?")
+	@Transactional
 	public void cancelStudy() {
 		StudyStatus statusWaitingForPayment = studyStatusService
 				.getStudyStatus(StudyStatus.ESPERANDO_COMPROBANTE_DE_PAGO);
 		getStudiesByActualStatus(statusWaitingForPayment).stream()
 				.filter(s -> s.getRecentCheckpoint().getCreatedAt().plusDays(30).compareTo(LocalDateTime.now()) < 0)
 				.forEach(study -> {
-					Checkpoint checkpoint = new Checkpoint();
-					checkpoint.setStudy(study);
-					checkpoint.setCreatedBy(null);
-					checkpoint.setStatus(studyStatusService.getStudyStatus(StudyStatus.ANULADO));
-					study.getCheckpoints().add(checkpoint);
+					StudyStatus studyStatus = studyStatusService.getStudyStatus(StudyStatus.ANULADO);
+					Checkpoint checkpoint = Checkpoint.builder().status(studyStatus).createdBy(null).build();
+					study.addCheckpoint(checkpoint);
 					studyRepository.save(study);
 				});
 	}
 
 	public Study getStudyBySample(Sample sample) {
-		return studyRepository.findBySample(sample)
-				.orElseThrow(() -> new BadRequestException("No existe un estudio para la muestra con id " + sample.getId() + "."));
+		return studyRepository.findBySample(sample).orElseThrow(
+				() -> new BadRequestException("No existe un estudio para la muestra con id " + sample.getId() + "."));
 	}
-
 
 	public List<StudyItemResponseDTO> getAllPatientStudies(Long patientId) {
 		patientService.validateLoggedPatient(patientId);
@@ -440,8 +456,10 @@ public class StudyService {
 	}
 
 	public BigDecimal payExtractionAmountStudies(UnpaidStudiesDTO unpaidStudiesDTO) {
-		unpaidStudiesDTO.getUnpaidStudies().forEach(studyId -> getStudy(studyId.longValue()).setPaidExtractionAmount(true));
-		return unpaidStudiesDTO.getUnpaidStudies().stream().map(studyId -> getStudy(studyId.longValue()).getExtractionAmount())
+		unpaidStudiesDTO.getUnpaidStudies()
+				.forEach(studyId -> getStudy(studyId.longValue()).setPaidExtractionAmount(true));
+		return unpaidStudiesDTO.getUnpaidStudies().stream()
+				.map(studyId -> getStudy(studyId.longValue()).getExtractionAmount())
 				.reduce(BigDecimal.ZERO, BigDecimal::add);
 	}
 
@@ -450,7 +468,7 @@ public class StudyService {
 	}
 
 	public Integer studiesByMonthOfYear(Integer month, Integer year) {
-		LocalDateTime from = LocalDateTime.of(year,month,1,0,0);
+		LocalDateTime from = LocalDateTime.of(year, month, 1, 0, 0);
 		LocalDateTime to = from.plusMonths(1);
 		return studyRepository.findByCreatedAtBetween(from, to).size();
 	}


### PR DESCRIPTION
Refactorizacion de codigo repetido para setear checkpoint.

Agrego `@Transactional`para garantizar un contexto transaccional y rollback en falla

Agrega columna  sample_id a study. Esto nos permite poder relacionar muestras fallidas con el estudio (sample tiene el id del estudio) y al estudio setearle sample en null o generar una nueva.
Agrega columna failed a sample | para saber que muestras fueron marcadas como fallidas.

Cambio en la respuesta de la api ` GET /sample-batch/id`


Para el caso de agregar la columna sample_id a study se deberia actualizar sample_id con el id de la muestra de ese estudio.
Otra opcion es boletear la bd y crear estudios y muestras de 0.

Prueben con la rama https://github.com/ttps-laboratorio/ui-laboratorio/tree/feature/mark-failed-samples-in-batch
